### PR TITLE
Bug on CURL return parameter

### DIFF
--- a/vendor/Am/LicenseChecker.php
+++ b/vendor/Am/LicenseChecker.php
@@ -427,7 +427,7 @@ class Am_LicenseChecker
             return array($status, $body, curl_errno($ch) . ':' . curl_error($ch));
         }
         $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        return array($status, $body, '');
+        return array($body, $status, '');
     }
     function openUrlFopen($method, $url, $params)
     {


### PR DESCRIPTION
according to this line https://github.com/CGI-Central/softsale-sample-app/blob/master/vendor/Am/LicenseChecker.php#L227
return parameter should be array( $body, $status , $errormessage )
